### PR TITLE
GitHub ActionsでCI/CDワークフローを構築しました。ラベルベースでデプロイ戦略を切り替えることで、EASビルド回数を節約します。

### DIFF
--- a/.github/workflows/eas-update-on-merge.yml
+++ b/.github/workflows/eas-update-on-merge.yml
@@ -29,6 +29,7 @@ jobs:
       - run: npm ci
 
       - name: EAS Update (JS bundle to dev channel)
-        run: npx eas-cli@latest update --branch dev --message "Deployed from main after PR #${{ github.event.pull_request.number }}" --non-interactive
+        run: npx eas-cli@latest update --branch dev --message "${MESSAGE}" --non-interactive
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          MESSAGE: "Deployed from main after PR #${{ github.event.pull_request.number }}"

--- a/setup-gh-actions.md
+++ b/setup-gh-actions.md
@@ -141,9 +141,10 @@ jobs:
       - run: npm ci
 
       - name: EAS Update (JS bundle to dev channel)
-        run: npx eas-cli@latest update --branch dev --message "Deployed from main after PR #${{ github.event.pull_request.number }}" --non-interactive
+        run: npx eas-cli@latest update --branch dev --message "${MESSAGE}" --non-interactive
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          MESSAGE: "Deployed from main after PR #${{ github.event.pull_request.number }}"
 ```
 
 ### 4-3) main へ merge + `native` ラベル付きなら Android build（重い）


### PR DESCRIPTION
- ✅ **verify.yml**: PR/ブランチpush時にtypecheck/lint/testを実行
- ✅ **eas-update-on-merge.yml**: main merge時にJS OTA配信（デフォルト）
- ✅ **eas-build-android-on-merge.yml**: `native`ラベル付きPR merge時のみAndroid buildを実行
- ✅ **package.json**: verify スクリプト追加
- ✅ **CLAUDE.md**: PRラベルルールとcc4wポリシー追加
- ✅ **setup-gh-actions.md**: 完全なセットアップドキュメント
- 🧪 **App.tsx**: v3→v4に変更（テスト用）